### PR TITLE
Feature/fixpaths

### DIFF
--- a/dataEng_container_tools/cla.py
+++ b/dataEng_container_tools/cla.py
@@ -336,8 +336,7 @@ class command_line_arguments:
         for pos, filename in enumerate(self.__args.input_filenames):
             if not constant_bucket:
                 bucket_name = self.__args.input_bucket_names[pos]
-            output.append("gs://" + bucket_name + "/" +
-                          self.__args.input_paths[pos] + "/" + filename)
+            output.append(f"gs://{bucket_name}/{self.__args.input_paths[pos]}/{filename}".replace("/ /","/").replace("/./","/"))
         return output
 
     def get_output_uris(self):
@@ -358,8 +357,7 @@ class command_line_arguments:
         for pos, filename in enumerate(self.__args.output_filenames):
             if not constant_bucket:
                 bucket_name = self.__args.output_bucket_names[pos]
-            output.append("gs://" + bucket_name + "/" +
-                          self.__args.output_paths[pos] + "/" + filename)
+            output.append(f"gs://{bucket_name}/{self.__args.output_paths[pos]}/{filename}".replace("/ /","/").replace("/./","/"))
         return output
 
     def get_secret_locations(self):

--- a/dataEng_container_tools/cla.py
+++ b/dataEng_container_tools/cla.py
@@ -336,7 +336,7 @@ class command_line_arguments:
         for pos, filename in enumerate(self.__args.input_filenames):
             if not constant_bucket:
                 bucket_name = self.__args.input_bucket_names[pos]
-            output.append(f"gs://{bucket_name}/{self.__args.input_paths[pos]}/{filename}".replace("/ /","/").replace("/./","/"))
+            output.append(f"gs://{bucket_name}/{self.__args.input_paths[pos]}/{filename}".replace("/ /","/").replace("/./","/").replace("//","/"))
         return output
 
     def get_output_uris(self):
@@ -357,7 +357,7 @@ class command_line_arguments:
         for pos, filename in enumerate(self.__args.output_filenames):
             if not constant_bucket:
                 bucket_name = self.__args.output_bucket_names[pos]
-            output.append(f"gs://{bucket_name}/{self.__args.output_paths[pos]}/{filename}".replace("/ /","/").replace("/./","/"))
+            output.append(f"gs://{bucket_name}/{self.__args.output_paths[pos]}/{filename}".replace("/ /","/").replace("/./","/").replace("//","/"))
         return output
 
     def get_secret_locations(self):


### PR DESCRIPTION
Release version: v0.5.4
We can now reference files in a bucket's root directory. Specifying the `input_path`s or `output_path`s with either `''` (an empty/null string), `' '` (a single space), or `'.'` (for _this directory_) will reduce to concatenating a single slash between the bucket name and the filename. 

code changes in the following function in gcs.py

get_input_uris
get_output_uris