### PR TITLE
fixing get_inputs/output_uris

### DIFF
--- a/dataEng_container_tools/cla.py
+++ b/dataEng_container_tools/cla.py
@@ -351,7 +351,7 @@ class command_line_arguments:
         for pos, filename in enumerate(self.__args.input_filenames):
             if not constant_bucket:
                 bucket_name = self.__args.input_bucket_names[pos]
-            output.append(f"gs://{bucket_name}/{self.__args.input_paths[pos]}/{filename}".replace("/ /","/").replace("/./","/").replace("//","/"))
+            output.append(r"gs://" + f"{bucket_name}/{self.__args.input_paths[pos]}/{filename}".replace("/ /","/").replace("/./","/").replace("//","/"))
         return output
 
     def get_output_uris(self):
@@ -372,7 +372,7 @@ class command_line_arguments:
         for pos, filename in enumerate(self.__args.output_filenames):
             if not constant_bucket:
                 bucket_name = self.__args.output_bucket_names[pos]
-            output.append(f"gs://{bucket_name}/{self.__args.output_paths[pos]}/{filename}".replace("/ /","/").replace("/./","/").replace("//","/"))
+            output.append(r"gs://" + f"{bucket_name}/{self.__args.output_paths[pos]}/{filename}".replace("/ /","/").replace("/./","/").replace("//","/"))
         return output
 
     def get_secret_locations(self):


### PR DESCRIPTION
PR #57 resulted in side effect of `get_input_uris()` and `get_output_uris()` returning uri strings with the gcs prefix missing a forward slash: (i.e `gs:/` instead of `gs://`). 

**Cause:** The replace methods are referencing the whole uri string when we just want the replace methods to affect the string pertaining to string characters from bucket_name -> bucket_path -> bucket_file, NOT uri prefix

```
current state:
[gs:/test_drop_columns_v2/clean_data_files/APAC_dtr_duplicates_removed.csv]

expected state:
[gs://test_drop_columns_v2/clean_data_files/APAC_dtr_duplicates_removed.csv]
```