### PR TITLE
check if table does not exist, raise exception

### DIFF
--- a/dataEng_container_tools/bq.py
+++ b/dataEng_container_tools/bq.py
@@ -27,7 +27,7 @@ from google.cloud.bigquery.job import CopyJob, CopyJobConfig
 from google.cloud.bigquery.job import WriteDisposition
 from google.cloud.bigquery.enums import SourceFormat
 from google.cloud.bigquery import DatasetReference, TableReference
-
+from google.cloud.exceptions import NotFound
 
 class BQ:
     """Interacts with BigQuery.
@@ -153,6 +153,11 @@ class BQ:
         job_results = {}
 
         client = self.bq_client
+
+        try:
+            client.get_table(table_id)
+        except NotFound:
+            raise NotFound(f"Create {table_id} using terraform in Github before running the container")
 
         project_id, ds_id, table_name = table_id.split(".")
         dataset = DatasetReference(project_id, ds_id)


### PR DESCRIPTION
Currently, there is an edgecase when running a dag, that has a task `LOAD_TO_BQ`:
- Terraform Apply Github Action has not finished
- Dag runs and tries to load the parquet file to the existing dataset, but the table does not exist yet
- The BQ API call will create a table that is not managed by Terraform 

On subsequent Terraform Apply Github actions, the action will fail because Terraform will detect that there is a duplicate table in the bigquery dataset.

The fix is to add a check to see if the table exists by calling `client.get_table`. This should throw a `NotFound` error that we catch and raise again with a message to have the user create the table first with Terraform using Github